### PR TITLE
get display serial number from CGDisplay if not exist in EDID

### DIFF
--- a/Calcifer/DisplayCommunication/DisplayCommunicator.swift
+++ b/Calcifer/DisplayCommunication/DisplayCommunicator.swift
@@ -33,6 +33,10 @@ final class DisplayCommunicator {
             }
         }
 
+        if serialNumber == nil {
+            serialNumber = String(CGDisplaySerialNumber(displayID))
+        }
+
         if let displayName = displayName, let serialNumber = serialNumber {
             return Display.Properties(name: displayName, serial: serialNumber)
         }


### PR DESCRIPTION
Hello.
Thanks for the software.
But for my monitors and/or video card, getting the serial number from EDID was not successful and monitors did not appear in the program, although everything was fine in the logs.
Therefore, I had to fix the getting of the serial number, as the DDC code does if I could not get it from the EDID.

![Снимок экрана 2020-02-14 в 05 11 55](https://user-images.githubusercontent.com/12181586/74474277-87721000-4ee8-11ea-8c57-c882124d0311.jpg)
